### PR TITLE
Updated manifest to support VS2019

### DIFF
--- a/XamlPowerToys/source.extension.vsixmanifest
+++ b/XamlPowerToys/source.extension.vsixmanifest
@@ -7,19 +7,19 @@
                   Version="1.5.32"
                   Language="en-US"
                   Publisher="Karl Shifflett" />
-        <DisplayName>XAML Power Toys for Visual Studio 2015 - 2017</DisplayName>
-        <Description xml:space="preserve">Visual Studio 2015 - 2017 extension that enables developers to rapidly generate data entry forms from view models or entity objects for Xamarin Forms, UPW, WPF, and Silverlight.</Description>
+        <DisplayName>XAML Power Toys for Visual Studio 2015 - 2019</DisplayName>
+        <Description xml:space="preserve">Visual Studio 2015 - 2019 extension that enables developers to rapidly generate data entry forms from view models or entity objects for Xamarin Forms, UPW, WPF, and Silverlight.</Description>
         <License>Resources\LICENSE</License>
         <Icon>Resources\Icon.png</Icon>
         <PreviewImage>Resources\Preview.png</PreviewImage>
         <Tags>xaml, xaml power toys, code generation, wpf, uwp, xamarin, silverlight</Tags>
     </Metadata>
     <Installation>
-        <InstallationTarget Version="[14.0,16.0)"
+        <InstallationTarget Version="[14.0,17.0)"
                             Id="Microsoft.VisualStudio.Enterprise" />
-        <InstallationTarget Version="[14.0,16.0)"
+        <InstallationTarget Version="[14.0,17.0)"
                             Id="Microsoft.VisualStudio.Community" />
-        <InstallationTarget Version="[14.0,16.0)"
+        <InstallationTarget Version="[14.0,17.0)"
                             Id="Microsoft.VisualStudio.Pro" />
     </Installation>
     <Dependencies>
@@ -27,10 +27,6 @@
                     DisplayName="Microsoft .NET Framework"
                     d:Source="Manual"
                     Version="[4.5,)" />
-        <Dependency Id="Microsoft.VisualStudio.MPF.14.0"
-                    DisplayName="Visual Studio MPF 14.0"
-                    d:Source="Installed"
-                    Version="[14.0]" />
     </Dependencies>
     <Assets>
         <Asset Type="Microsoft.VisualStudio.VsPackage"
@@ -40,7 +36,7 @@
     </Assets>
     <Prerequisites>
         <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor"
-                      Version="[15.0.26208.0,16.0)"
+                      Version="[15.0,)"
                       DisplayName="Visual Studio core editor" />
     </Prerequisites>
 </PackageManifest>


### PR DESCRIPTION
Updated the Manifest to support VS2019 based on this article:

https://devblogs.microsoft.com/visualstudio/how-to-upgrade-extensions-to-support-visual-studio-2019/

Extension Installs & Tested with VS 2019 Community